### PR TITLE
FERCO/AVIDSEN/ALIBABA RF Heat_Cold thermostat for aerothermal systems

### DIFF
--- a/custom_components/tuya_local/devices/heat_cold_thermostat_v2.yaml
+++ b/custom_components/tuya_local/devices/heat_cold_thermostat_v2.yaml
@@ -1,0 +1,62 @@
+name: Heat Cold thermostat v2
+entities:
+  - entity: climate
+    dps:
+      - id: 2
+        type: integer
+        name: temperature
+        unit: C
+        range:
+          min: 50
+          max: 350
+        mapping:
+          - step: 5
+            scale: 10
+      - id: 3
+        type: integer
+        name: current_temperature
+        mapping:
+          - scale: 10
+      - id: 1
+        type: boolean
+        name: hvac_mode
+        mapping:
+          - dps_val: true
+            constraint: cool_heat
+            conditions:
+              - dps_val: true
+                value: cool
+              - dps_val: false
+                value: heat
+          - dps_val: false
+            value: "off"
+      - id: 6
+        type: boolean
+        name: cool_heat
+        mapping:
+          - dps_val: true
+            value: cool
+          - dps_val: false
+            value: heat
+      - id: 14
+        type: string
+        name: hvac_action
+        mapping:
+          - dps_val: no_working
+            value: idle
+          - dps_val: working
+            constraint: cool_heat
+            conditions:
+              - dps_val: true
+                value: cooling
+              - dps_val: false
+                value: heating
+          - dps_val: window_opened
+            value: idle
+  - entity: lock
+    translation_key: child_lock
+    category: config
+    dps:
+      - id: 7
+        type: boolean
+        name: lock


### PR DESCRIPTION
This change adds support for generic tuya heat/cold RF thermostats, the ones that are usually supplied with aerothermal systems.

Tested with "FERCO GN1" thermostats ([link](https://tucalentadoreconomico.es/accesorios-calderas/2410-cronotermostato-sin-cable-frio-calor-ferco-gn1r.html)), although I have seen them branded aso as "Avidsen" ([link](https://www.elcorteingles.es/electronica/A43033585-termostato-inalambrico-wifi-conectado/?awc=13075_1740318172_7eb0f5591da27ea99962fd6036d9b984&aff_id=2118094&dclid=COGZ17P22YsDFfCaJwIdIFMGTg)). In the end, these are simply generic alibaba RF thermostats with a Wifi Bridge as I have checked ([link](https://etopcontrol.en.made-in-china.com/product/cJirybkUCDVS/China-Smart-WiFi-Room-Best-Thermostat-for-Underfloor-Heating-System-Thermostat.html?pv_id=1ikpgha3q1c3&faw_id=1ikpghl93890))

![termostato](https://github.com/user-attachments/assets/0e199916-be42-4158-b749-52211842cdac)

This modification adds support and permits setting temperatures, check if it's working or idle, change mode from heat to cold to off seamlessly and child lock them.  Works flawlessly (and much better than in the official tuya app, where setting heat/cold mode is an obscure mislabeled setting).

![termostato](https://github.com/user-attachments/assets/f8ac42d9-b758-4ecd-beaf-faa4b7efd1c6)
![entidad](https://github.com/user-attachments/assets/373b289e-0f38-4a34-bac7-dcd793bba41d)

Already tested and working successfully at home with 8 thermostats running from 2 RF-WIFI bridges.


